### PR TITLE
Use Closure goog.events for events handling instead of jQuery.

### DIFF
--- a/src/hoplon/core.cljs
+++ b/src/hoplon/core.cljs
@@ -9,6 +9,7 @@
 (ns hoplon.core
   (:require
     [goog.Uri]
+    [goog.events :as events]
     [cljsjs.jquery]
     [clojure.set    :refer [difference intersection]]
     [javelin.core   :refer [cell? cell lift destroy-cell!]]
@@ -557,9 +558,13 @@
   cljs.core/IDeref
   (-deref [this] (-> this .-target js/jQuery .val)))
 
+(extend-type goog.events.Event
+  cljs.core/IDeref
+  (-deref [this] (.-target this)))
+
 (defmethod on! ::default
   [elem event callback]
-  (when-dom elem #(.on (js/jQuery elem) (name event) callback)))
+  (when-dom elem #(events/listen elem (name event) callback)))
 
 (defn loop-tpl*
   [items tpl]


### PR DESCRIPTION
This is a POC for using `goog.events.listen` instead of jQuery to avoid memory leaks caused by jQuery.cache retaining references to callback functions.

With this patch the following code doesn't require manual memory management using `jQuery(elem).parent().empty()` or `jQuery.cleanData(...)` for the following case:

Currently when Hoplon uses jQuery to manage events the following code is needed to avoid memory leaks of `HTMLSpanElement` objects (retained in `jQuery.cache`):

```clojure
(page "index.html")

(def show? (cell true))

(html
  (body
    (div
      (let [node (atom nil)]
        (.setInterval js/window #(swap! show? not) 100)
        (cell=
          (if show?
            (with-let [new-node (span "Hi" :click #(.log js/console "OK"))]
              (reset! node new-node))
            (do
              (.empty (.parent (js/jQuery @node)))
              (reset! node nil)
              nil)))))))
```

With the patch the following simple code works without leaks:

```clojure
(page "index.html")

(def show? (cell true))

(html
  (body
    (div
      (.setInterval js/window #(swap! show? not) 100)
      (cell=
        (when show?
          (span "Hi" :click #(.log js/console "OK")))))))
```

Of course it won't help if references to DOM nodes are retained in other places preventing them from being GCed but could be useful in simpler scenarios.