### PR TITLE
implements if-tpl for conditional display of elements

### DIFF
--- a/src/hoplon/core.clj
+++ b/src/hoplon/core.clj
@@ -161,8 +161,8 @@
 
 (defmacro if-tpl
   "Conditionally displays templates. Delays evaluation of templates until flow is determined."
-  [& args]
-  (let [[_ {truth :pred} [true-tpl false-tpl]] (parse-e (cons '_ args))]
+  [truth true-tpl & args]
+  (let [[false-tpl] args]
     `(if-tpl* ~truth
               (fn [] ~true-tpl)
               (fn [] ~false-tpl))))

--- a/src/hoplon/core.clj
+++ b/src/hoplon/core.clj
@@ -159,6 +159,14 @@
     `(loop-tpl* ~items
        (fn [item#] (j/cell-let [~bindings item#] ~body)))))
 
+(defmacro if-tpl
+  "Conditionally displays templates. Delays evaluation of templates until flow is determined."
+  [& args]
+  (let [[_ {truth :pred} [true-tpl false-tpl]] (parse-e (cons '_ args))]
+    `(if-tpl* ~truth
+              (fn [] ~true-tpl)
+              (fn [] ~false-tpl))))
+
 (defmacro with-dom
   [elem & body]
   `(when-dom ~elem (fn [] ~@body)))

--- a/src/hoplon/core.cljs
+++ b/src/hoplon/core.cljs
@@ -35,10 +35,6 @@
 
 ;;;; public helpers ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defn xor [a b]
-  (and (or a b)
-       (not (and a b))))
-
 (defn do-watch
   ([atom f]
    (do-watch atom nil f))

--- a/src/hoplon/core.cljs
+++ b/src/hoplon/core.cljs
@@ -590,6 +590,15 @@
                       (swap! current pop)
                       (swap! on-deck conj e))))))))))
 
+(defn if-tpl* [truth true-tpl false-tpl]
+  (with-let [current (with-meta (cell nil) {:preserve-event-handlers true})]
+    (do-watch truth
+              (fn [old-truth new-truth]
+                (reset! current
+                        (if new-truth
+                          (true-tpl)
+                          (false-tpl)))))))
+
 (defn route-cell
   [& [default]]
   (let [c (cell (.. js/window -location -hash))]

--- a/src/hoplon/core.cljs
+++ b/src/hoplon/core.cljs
@@ -604,7 +604,7 @@
                     (let [c @current
                           d @cache]
                       ;; if current view is not nil, then cache it.
-                      (if c (reset! cache c))
+                      (reset! cache c)
                       (reset! current (or d ;; if cache exists, set cache as the current view
                                           ;; otherwise, evaluate and return appropriate template.
                                           (if new


### PR DESCRIPTION
Use cases:

- When performing recursion, and `loop-tpl` is an inappropriate tool, this should be used to prevent the premature evaluation of the recursive case.
- When controlling the visibility of a member of an arbitrarily arranged set of elements, this can prevent unintended css effects when using sibling selectors like `+` or nth-selectors like `first-of-type`.
- In general, when controlling the visibility of an element, and `display: none` is not appropriate. 