### PR TITLE
Properly implement insertBefore on Element

### DIFF
--- a/src/hoplon/core.cljs
+++ b/src/hoplon/core.cljs
@@ -137,7 +137,9 @@
           (this-as this
             (with-let [x x]
               (ensure-kids! this)
-              (swap! (kidfn this) #(vec (mapcat (fn [z] (if (= z y) [x z] [z])) %))))))))
+              (cond
+                (not y)     (swap! (kidfn this) conj x)
+                (not= x y)  (swap! (kidfn this) #(vec (mapcat (fn [z] (if (= z y) [x z] [z])) %)))))))))
 
 (defn- set-replaceChild!
   [this kidfn]


### PR DESCRIPTION
This was causing an issue with D3.

```javascript
foo.insertBefore(x, null); // should be the same as foo.appendChild(x)
```
and
```javascript
foo.insertBefore(x, x); // should be a no-op
```
