### PR TITLE
Don't ever call jQuery#remove() on elements

### DIFF
--- a/src/hoplon/core.cljs
+++ b/src/hoplon/core.cljs
@@ -82,8 +82,6 @@
 (def ^:private replaceChild (.. js/Element -prototype -replaceChild))
 (def ^:private setAttribute (.. js/Element -prototype -setAttribute))
 
-(def ^:private ^:dynamic *preserve-event-handlers* false)
-
 (defn- merge-kids
   [this old new]
   (let [new  (remove nil? (flatten new))
@@ -98,9 +96,7 @@
                                   (when-not (new? k)
                                     (let [n (->node k)]
                                       (when (= this (.-parentNode n))
-                                        (.call removeChild this n)
-                                        (when-not *preserve-event-handlers*
-                                          (.remove (js/jQuery n)))))))
+                                        (.call removeChild this n)))))
                         :else   (with-let [kids kids]
                                   (.call insertBefore this (->node x) (->node k)))))))))
 
@@ -122,9 +118,7 @@
               (let [kids (kidfn this)
                     i    (count @kids)]
                 (if (cell? x)
-                  (let [preserve? (:preserve-event-handlers (meta x))]
-                    (do-watch x #(binding [*preserve-event-handlers* preserve?]
-                                   (swap! kids assoc i %2))))
+                  (do-watch x #(swap! kids assoc i %2))
                   (swap! kids assoc i x))))))))
 
 (defn- set-removeChild!
@@ -591,7 +585,7 @@
         items-seq (cell= (seq items))
         ith-item  #(cell= (safe-nth items-seq %))
         shift!    #(with-let [x (first @%)] (swap! % rest))]
-    (with-let [current (with-meta (cell []) {:preserve-event-handlers true})]
+    (with-let [current (cell [])]
       (do-watch items-seq
         (fn [old-items new-items]
           (let [old  (count old-items)


### PR DESCRIPTION
The user should do this, instead. When Hoplon does it automatically it
can interfere with the operation of jQuery plugins that move elements
into and out of the DOM (because when Hoplon calls .remove() on the
element all event handlers are removed, which can break the plugin).

The main use case was to accomodate using cell= in place of loop-tpl,
like this:

        (ul (cell= (map li items)))

This can still be accomplished with a little scaffolding:

        (ul (doto (cell= (map li items))
              (add-watch (gensym)
                (fn [_ _ prev next]
                  (when (not= prev next)
                    (doseq [p prev]
                      (.remove (js/jQuery p))))))))

Or use loop-tpl and avoind needing to call .remove() at all:

        (ul (loop-tpl :bindings [i items] (li i)))