### PR TITLE
Remove unneeded check in merge-kids

### DIFF
--- a/src/hoplon/core.cljs
+++ b/src/hoplon/core.cljs
@@ -94,9 +94,7 @@
                                   (.call appendChild this (->node x)))
                         (not x) (with-let [ks ks]
                                   (when-not (new? k)
-                                    (let [n (->node k)]
-                                      (when (= this (.-parentNode n))
-                                        (.call removeChild this n)))))
+                                    (.call removeChild this (->node k))))
                         :else   (with-let [kids kids]
                                   (.call insertBefore this (->node x) (->node k)))))))))
 


### PR DESCRIPTION
Doesn't seem like we still want to check for `(.-parentNode)`. Don't think it's possible to hook into the basic `removeChild`/`insertBefore`/`appendChild` and mess with the DOM while iterating once we got rid of `jQuery.remove`.