### PR TITLE
implements recursive watch for cells in appendChild

### DIFF
--- a/src/hoplon/core.cljs
+++ b/src/hoplon/core.cljs
@@ -106,6 +106,11 @@
         (set! (.-hoplonKids this) kids)
         (do-watch kids (partial merge-kids this))))))
 
+(defn- babysitter [x kids i]
+  (if (cell? x)
+    (do-watch x #(babysitter %2 kids i))
+    (swap! kids assoc i x)))
+
 (defn- set-appendChild!
   [this kidfn]
   (set! (.-appendChild this)
@@ -115,9 +120,8 @@
               (ensure-kids! this)
               (let [kids (kidfn this)
                     i    (count @kids)]
-                (if (cell? x)
-                  (do-watch x #(swap! kids assoc i %2))
-                  (swap! kids assoc i x))))))))
+                (babysitter x kids i)))))))
+
 
 (defn- set-removeChild!
   [this kidfn]

--- a/src/hoplon/core.cljs
+++ b/src/hoplon/core.cljs
@@ -106,9 +106,10 @@
         (set! (.-hoplonKids this) kids)
         (do-watch kids (partial merge-kids this))))))
 
-(defn- babysitter [x kids i]
+;; find a way to make the swap!s traverse the tree properly instead of skipping to the end.
+(defn- babysitter [kids i x]
   (if (cell? x)
-    (do-watch x #(babysitter %2 kids i))
+    (do-watch x #(babysitter kids i %2))
     (swap! kids assoc i x)))
 
 (defn- set-appendChild!
@@ -120,7 +121,7 @@
               (ensure-kids! this)
               (let [kids (kidfn this)
                     i    (count @kids)]
-                (babysitter x kids i)))))))
+                (babysitter kids i x)))))))
 
 
 (defn- set-removeChild!


### PR DESCRIPTION
This should allow template macros to nest without intermediary nodes.

Basic case:

```clj
(let [a (cell true)
  b (cell true)]
  (div
    (button :click #(swap! a not) "toggle a")
    (button :click #(swap! b not) "toggle b")
    (if-tpl a
      (if-tpl b
        (div "ab")
        (div "a")
      (div "not a")))
```