### PR TITLE
restore support for cells in the head and body elements. closes #116.

### DIFF
--- a/src/hoplon/core.cljs
+++ b/src/hoplon/core.cljs
@@ -304,11 +304,10 @@
     (let [[attrs kids] (parse-args args)
           elem         (-> js/document
                            (.getElementsByTagName tag)
-                           (aget 0)
-                           ensure-kids!)]
+                           (aget 0))]
       (add-attributes! elem attrs)
       (when (not (:static attrs))
-        (reset! (.-hoplonKids elem) (vec kids))))))
+        (add-children! elem kids)))))
 
 (defn- make-elem-ctor
   [tag]

--- a/src/hoplon/core.cljs
+++ b/src/hoplon/core.cljs
@@ -307,6 +307,7 @@
                            (aget 0))]
       (add-attributes! elem attrs)
       (when (not (:static attrs))
+        (set! (.-innerHTML elem) nil)
         (add-children! elem kids)))))
 
 (defn- make-elem-ctor


### PR DESCRIPTION
the singleton constructors were appending all of their children,
elements and cells alike, into the hoplonKids atom; this fired a watch
that in turn passed these unexpected cells into merge-kids (instead of
any elements they contained).

invoking add-children! from the constructor resolves this issue.  this
fix appears suspiciously straightforward, however, suggesting that it
might be trading one regression for another.  it is unclear, however,
what the other cases necessitating a more nuanced approach might be.