### PR TITLE
attribute namespaces

### DIFF
--- a/src/hoplon/core.cljs
+++ b/src/hoplon/core.cljs
@@ -481,17 +481,21 @@
 
 (defmulti do!
   (fn [elem key val]
-    (if-let [n (namespace key)] (keyword "ns" n) key)) :default ::default)
+    (if-let [n (namespace key)] (keyword n "*") key)) :default ::default)
 
 (defmethod do! ::default
   [elem key val]
   (do! elem :attr {key val}))
 
-(defmethod do! :ns/css
+(defmethod do! :css/*
   [elem key val]
   (.css (js/jQuery elem) (name key) (str val)))
 
-(defmethod do! [:ns/html :ns/svg]
+(defmethod do! :html/*
+  [elem key val]
+  (.attr (js/jQuery elem) (name key) (str val)))
+
+(defmethod do! :svg/*
   [elem key val]
   (.attr (js/jQuery elem) (name key) (str val)))
 
@@ -567,13 +571,19 @@
           elem (js/jQuery elem)]
       (.animate body (clj->js {:scrollTop (.-top (.offset elem))})))))
 
-(defmulti on! (fn [elem event callback] event) :default ::default)
+(defmulti on!
+  (fn [elem key val]
+    (if-let [n (namespace key)] (keyword n "*") key)) :default ::default)
 
 (extend-type js/jQuery.Event
   cljs.core/IDeref
   (-deref [this] (-> this .-target js/jQuery .val)))
 
 (defmethod on! ::default
+  [elem event callback]
+  (when-dom elem #(.on (js/jQuery elem) (name event) callback)))
+
+(defmethod on! :html/*
   [elem event callback]
   (when-dom elem #(.on (js/jQuery elem) (name event) callback)))
 

--- a/src/hoplon/core.cljs
+++ b/src/hoplon/core.cljs
@@ -481,17 +481,17 @@
 
 (defmulti do!
   (fn [elem key val]
-    (if-let [ctx (namespace key)] (keyword "ctx" ctx) key)) :default ::default)
+    (if-let [n (namespace key)] (keyword "ns" n) key)) :default ::default)
 
 (defmethod do! ::default
   [elem key val]
   (do! elem :attr {key val}))
 
-(defmethod do! :ctx/css
+(defmethod do! :ns/css
   [elem key val]
   (.css (js/jQuery elem) (name key) (str val)))
 
-(defmethod do! :ctx/html
+(defmethod do! [:ns/html :ns/svg]
   [elem key val]
   (.attr (js/jQuery elem) (name key) (str val)))
 

--- a/src/hoplon/core.cljs
+++ b/src/hoplon/core.cljs
@@ -479,7 +479,9 @@
 
 ;; custom attributes ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defmulti do! (fn [elem key val] key) :default ::default)
+(defmulti do!
+  (fn [elem key val]
+    (if-let [ctx (namespace key)] (keyword ctx) key)) :default ::default)
 
 (defmethod do! ::default
   [elem key val]

--- a/src/hoplon/core.cljs
+++ b/src/hoplon/core.cljs
@@ -487,6 +487,14 @@
   [elem key val]
   (do! elem :attr {key val}))
 
+(defmethod do! :ctx/css
+  [elem key val]
+  (.css (js/jQuery elem) (name key) (str val)))
+
+(defmethod do! :ctx/html
+  [elem key val]
+  (.attr (js/jQuery elem) (name key) (str val)))
+
 (defmethod do! :value
   [elem _ & args]
   (let [e (js/jQuery elem)]

--- a/src/hoplon/core.cljs
+++ b/src/hoplon/core.cljs
@@ -481,7 +481,7 @@
 
 (defmulti do!
   (fn [elem key val]
-    (if-let [ctx (namespace key)] (keyword ctx) key)) :default ::default)
+    (if-let [ctx (namespace key)] (keyword "ctx" ctx) key)) :default ::default)
 
 (defmethod do! ::default
   [elem key val]


### PR DESCRIPTION
same idea a couple years later, but with a more general implementation.  permits css and html attributes to be passed through a namespaced attribute instead of being nested within a data structure.  fully backwards compatible. 
```clojure
(button  :css/width "200px" :css/height "60px" "Push Me")
```