### PR TITLE
mention cljson removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,6 @@ the following libraries as dependencies to complete the stack:
   elements to the underlying Javelin cell graph.
 * [Castra][2]: a full-featured RPC library for Clojure and
   ClojureScript, providing the serverside environment.
-* [Cljson][3]: an efficient method for transferring Clojure/ClojureScript
-  data between client and server. Castra uses cljson as the underlying
-  transport protocol.
 
 ### Documentation
 


### PR DESCRIPTION
From Clojurian Slack Hoplon channel :
```
leontalbot [9:23 AM] 
Hello! @alandipert @micha Should Hoplon readme mention Transit instead of Cljson?
jumblerg [9:42 AM] 
@leontalbot: if you’re updating the readme, i imagine it should probably be struck from it entirely, since transit is merely a dependency of castra (and cljson has been deprecated in favor of transit).
```