### PR TITLE
fixed "use" collision with hoplon.core

### DIFF
--- a/src/hoplon/svg.cljs
+++ b/src/hoplon/svg.cljs
@@ -1,5 +1,5 @@
 (ns hoplon.svg
-  (:refer-clojure :exclude [symbol filter mask set])
+  (:refer-clojure :exclude [symbol filter mask set use])
   (:require
     [hoplon.core :refer [ensure-kids! do!]]))
 


### PR DESCRIPTION
Caused this error when trying to hack plotSVG demo into a new empty project.

`WARNING: Can't take value of macro cljs.core/use at line 88 /home/kevin/.boot/cache/tmp/home/kevin/0work/hoplon/aaa/n4o/nyg3lv/index.html.out/hoplon/svg.cljs
WARNING: use already refers to: cljs.core/use being replaced by: hoplon.svg/use at line 88 /home/kevin/.boot/cache/tmp/home/kevin/0work/hoplon/aaa/n4o/nyg3lv/index.html.out/hoplon/svg.clj`