### PR TITLE
Merge boot-hoplon back into hoplon

### DIFF
--- a/boot.properties
+++ b/boot.properties
@@ -1,1 +1,5 @@
-BOOT_EMIT_TARGET=no
+#http://boot-clj.com
+#Sun Oct 23 15:31:28 EDT 2016
+BOOT_CLOJURE_NAME=org.clojure/clojure
+BOOT_CLOJURE_VERSION=1.7.0
+BOOT_VERSION=2.6.0

--- a/build.boot
+++ b/build.boot
@@ -42,5 +42,6 @@
           :url         "https://github.com/hoplon/hoplon"
           :scm         {:url "https://github.com/hoplon/hoplon"}
           :license     {"Eclipse Public License" "http://www.eclipse.org/legal/epl-v10.html"}}
+  test   {:namespaces '#{hoplon.app-test}}
   serve  {:port 3020}
   target {:dir #{"target"}})

--- a/build.boot
+++ b/build.boot
@@ -2,16 +2,15 @@
   :asset-paths    #{"tst/rsc"}
   :source-paths   #{"src" "tst/src"}
   :resource-paths #{"tst/tst"}
-  :dependencies '[[org.clojure/clojure                   "1.7.0"    :scope "provided"]
-                  [org.clojure/clojurescript             "1.7.122"  :scope "provided"]
-                  [adzerk/boot-cljs                      "1.7.48-3" :scope "test"]
+  :dependencies '[[adzerk/boot-cljs                      "1.7.48-3" :scope "test"]
                   [adzerk/bootlaces                      "0.1.13"   :scope "test"]
-                  [hoplon/boot-hoplon                    "0.2.0"    :scope "test"]
                   [adzerk/boot-reload                    "0.4.11"   :scope "test"]
                   [adzerk/boot-test                      "1.1.2"    :scope "test"]
                   [clj-webdriver                         "0.7.2"    :scope "test"]
                   [tailrecursion/boot-static             "0.1.0"    :scope "test"]
                   [org.seleniumhq.selenium/selenium-java "2.53.1"   :scope "test"]
+                  [org.clojure/clojure                   "1.7.0"]
+                  [org.clojure/clojurescript             "1.7.122"]
                   [cljsjs/jquery                         "1.9.1-0"]
                   [hoplon/javelin                        "3.8.4"]])
 

--- a/src/hoplon/boot_hoplon.clj
+++ b/src/hoplon/boot_hoplon.clj
@@ -1,0 +1,200 @@
+;; Copyright (c) Alan Dipert and Micha Niskin. All rights reserved.
+;; The use and distribution terms for this software are covered by the
+;; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;; which can be found in the file epl-v10.html at the root of this distribution.
+;; By using this software in any fashion, you are agreeing to be bound by
+;; the terms of this license.
+;; You must not remove this notice, or any other, from this software.
+
+(ns hoplon.boot-hoplon
+  {:boot/export-tasks true}
+  (:require [boot.core        :as boot]
+            [boot.pod         :as pod]
+            [boot.util        :as util]
+            [boot.file        :as file]
+            [clojure.java.io  :as io]
+            [clojure.string   :as string]
+            [hoplon.boot-hoplon.refer :as refer]))
+
+(def ^:private renderjs
+  "
+var page = require('webpage').create(),
+    sys  = require('system'),
+    path = sys.args[1]
+    uri  = \"file://\" + path + \"?prerendering=1\";
+page.open(uri, function(status) {
+  setTimeout(function() {
+    var html = page.evaluate(function() {
+      return document.documentElement.outerHTML;
+    });
+    console.log(html);
+    phantom.exit();
+  }, 0);
+});")
+
+(def hoplon-pod
+  (delay (pod/make-pod (->> (-> "hoplon/boot_hoplon/pod_deps.edn"
+                                io/resource slurp read-string)
+                            (update-in pod/env [:dependencies] into)))))
+
+(defn bust-cache
+  [path]
+  (pod/with-eval-in @hoplon-pod
+    (require 'hoplon.core)
+    (hoplon.core/bust-cache ~path)))
+
+(defn- by-path
+  [paths tmpfiles]
+  (boot/by-re (mapv #(re-pattern (str "^\\Q" % "\\E$")) paths) tmpfiles))
+
+(boot/deftask bust-caches
+  [p paths PATH #{str} "The set of paths to add cache-busting uuids to."]
+  (let [tmp (boot/tmp-dir!)]
+    (boot/with-pre-wrap fs
+      (let [msg (delay (util/info "Busting cache...\n"))]
+        (->> (boot/output-files fs)
+             (by-path paths)
+             (seq)
+             (reduce (fn [fs {:keys [path]}]
+                       @msg
+                       (util/info "• %s\n" path)
+                       (boot/mv fs path (bust-cache path)))
+                     fs))))))
+
+(boot/deftask prerender
+  [e engine ENGINE str "PhantomJS-compatible engine to use."]
+  (let [engine       (or engine "phantomjs")
+        pod          (future @hoplon-pod)
+        tmp          (boot/tmp-dir!)
+        rjs-tmp      (boot/tmp-dir!)
+        rjs-path     (.getPath (io/file rjs-tmp "render.js"))]
+    (spit rjs-path renderjs)
+    (boot/with-pre-wrap fileset
+      (let [html (->> fileset
+                      boot/output-files
+                      (boot/by-ext [".html"])
+                      (map (juxt boot/tmp-path (comp (memfn getPath)
+                                                     boot/tmp-file))))]
+        (pod/with-call-in @pod
+          (hoplon.boot-hoplon.impl/prerender
+            ~engine ~(.getPath tmp) ~rjs-path ~html))
+        (-> fileset (boot/add-resource tmp) boot/commit!)))))
+
+(defn- fspath->jarpath
+  [fspath]
+  (->> fspath file/split-path (string/join "/")))
+
+(defn- write-manifest!
+  [fileset dir]
+  (let [msg (delay (util/info "Writing Hoplon manifest...\n"))
+        out (io/file dir "hoplon" "manifest.edn")]
+    (when-let [hls (seq (->> fileset
+                             boot/output-files
+                             (boot/by-ext [".hl"])
+                             (map (comp fspath->jarpath boot/tmp-path))))]
+      @msg
+      (doseq [h hls] (util/info "• %s\n" h))
+      (spit (doto out io/make-parents) (pr-str (vec hls))))
+    (boot/add-resource fileset dir)))
+
+(defn- jar-resource?
+  [url]
+  (= "jar" (.getProtocol url)))
+
+(defn- extract-deps!
+  [dir]
+  (let [msg (delay (util/info "Extracting Hoplon dependencies...\n"))
+        mfs (->> "hoplon/manifest.edn" pod/resources (filter jar-resource?))]
+    (doseq [path (mapcat (comp read-string slurp) mfs)]
+      @msg
+      (util/info "• %s\n" path)
+      (pod/copy-resource path (io/file dir path)))))
+
+(boot/deftask ns+
+  "Extended ns declarations in CLJS."
+  []
+  (let [prev-fileset (atom nil)
+        tmp-cljs+    (boot/tmp-dir!)]
+    (boot/with-pre-wrap fileset
+      (let [cljses    (->> (boot/fileset-diff @prev-fileset fileset)
+                           (boot/input-files)
+                           (boot/by-ext [".cljs"])
+                           (group-by boot/tmp-path))
+            cljsdep   (->> cljses (keys) (refer/sort-dep-order))
+            add-tmp!  (fn [fs]
+                        (-> fs (boot/add-resource tmp-cljs+) boot/commit!))
+            desc      (delay (util/info "Rewriting ns+ declarations...\n"))
+            say-it    (fn [path] @desc (util/info "• %s\n" path))]
+        (reset! prev-fileset fileset)
+        (doseq [path cljsdep]
+          (let [f (io/file tmp-cljs+ path)]
+            (when (.exists f) (io/delete-file f))))
+        (loop [[path & paths] cljsdep fs (add-tmp! fileset)]
+          (if-not path fs
+            (let [modtime (.lastModified (boot/tmp-file (first (cljses path))))]
+              (refer/rewrite-ns-path say-it modtime tmp-cljs+ path)
+              (recur paths (add-tmp! fs)))))))))
+
+(defn- on-classpath?
+  [ns-sym]
+  (let [base (-> ns-sym munge str (.replaceAll "\\." "/"))]
+    (or (io/resource (str base ".cljs"))
+        (io/resource (str base ".cljc")))))
+
+(boot/deftask hoplon
+  "Build Hoplon web application."
+  [p pretty-print bool    "Pretty-print CLJS files created by the Hoplon compiler."
+   b bust-cache   bool    "Add cache-busting uuid to JavaScript file name."
+   m manifest     bool    "Create Hoplon manifest for jars that include .hl files."
+   r refers VAL   #{sym}  "The set of namespaces to refer (including macros) in all .hl files. Default is #{hoplon.jquery}."]
+  (let [prev-fileset (atom nil)
+        tmp-hl       (boot/tmp-dir!)
+        tmp-cljs     (boot/tmp-dir!)
+        tmp-html     (boot/tmp-dir!)
+        pod          (future @hoplon-pod)
+        extract!     (delay (extract-deps! tmp-hl))]
+    (comp
+      (if manifest
+        (boot/with-pre-wrap fileset
+          (-> fileset (write-manifest! tmp-hl) boot/commit!))
+        (boot/with-pre-wrap fileset
+          @extract!
+          (let [fileset (boot/commit!
+                          (boot/add-source
+                            fileset
+                            tmp-hl
+                            :mergers pod/standard-jar-mergers))
+                hls     (->> fileset
+                             (boot/fileset-diff @prev-fileset)
+                             boot/input-files
+                             (boot/by-ext [".hl"])
+                             (map boot/tmp-path))
+                cljses  (->> fileset
+                             (boot/fileset-diff @prev-fileset)
+                             boot/input-files
+                             (boot/by-ext [".cljs"])
+                             (map boot/tmp-path))
+                refers  (->> (or refers #{'hoplon.jquery})
+                             (filter on-classpath?)
+                             (set))
+                options (assoc *opts* :refers refers)]
+            (reset! prev-fileset fileset)
+            (pod/with-call-in @pod
+              (hoplon.boot-hoplon.impl/hoplon
+                ~(.getPath tmp-cljs)
+                ~(.getPath tmp-html)
+                [~@(concat hls cljses)]
+                ~options))
+            (-> fileset
+                (boot/add-source tmp-cljs)
+                (boot/add-resource tmp-html)
+                boot/commit!))))
+      (ns+))))
+
+(boot/deftask html2cljs
+  "Convert file from html syntax to cljs syntax."
+  [f file FILENAME str "File to convert."]
+  (let [pod (future @hoplon-pod)]
+    (boot/with-pre-wrap fileset
+      (print (pod/with-call-in @pod (hoplon.boot-hoplon.impl/html2cljs ~file)))
+      fileset)))

--- a/src/hoplon/boot_hoplon/compiler.clj
+++ b/src/hoplon/boot_hoplon/compiler.clj
@@ -1,0 +1,149 @@
+;; Copyright (c) Alan Dipert and Micha Niskin. All rights reserved.
+;; The use and distribution terms for this software are covered by the
+;; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;; which can be found in the file epl-v10.html at the root of this distribution.
+;; By using this software in any fashion, you are agreeing to be bound by
+;; the terms of this license.
+;; You must not remove this notice, or any other, from this software.
+
+(ns hoplon.boot-hoplon.compiler
+  (:require
+    cljs.util
+    [clojure.pprint             :as pp]
+    [clojure.java.io            :as io]
+    [clojure.string             :as string]
+    [clojure.set                :as set]
+    [hoplon.core                :as hl]
+    [hoplon.boot-hoplon.tagsoup :as tags]
+    [hoplon.boot-hoplon.refer   :as refer])
+  (:import
+    [clojure.lang LineNumberingPushbackReader]
+    [java.io PushbackReader BufferedReader StringReader]))
+
+(def ^:dynamic *printer* prn)
+
+(defn munge-page-name [x]
+  (-> (str "_" (name x)) (string/replace #"\." "_DOT_") munge))
+
+(defn munge-page [ns]
+  (let [ap "hoplon.app-pages."]
+    (if (symbol? ns) ns (symbol (str ap (munge-page-name ns))))))
+
+(defn read-string-1
+  [x]
+  (when x
+    (with-open [r (LineNumberingPushbackReader. (StringReader. x))]
+      [(read r false nil)
+       (apply str (concat (repeat (dec (.getLineNumber r)) "\n") [(slurp r)]))])))
+
+(defn up-parents [path name]
+  (let [[f & dirs] (string/split path #"/")]
+    (->> [name] (concat (repeat (count dirs) "../")) (apply str))))
+
+(defn inline-code [s process]
+  (let [lines (string/split s #"\n")
+        start #";;\{\{\s*$"
+        end #"^\s*;;\}\}\s*$"
+        pad #"^\s*"
+        unpad #(string/replace %1 (re-pattern (format "^\\s{0,%d}" %2)) "")]
+    (loop [txt nil, i 0, [line & lines] lines, out []]
+      (if-not line
+        (string/join "\n" out)
+        (if-not txt
+          (if (re-find start line)
+            (recur [] i lines out)
+            (recur txt i lines (conj out line)))
+          (if (re-find end line)
+            (let [s (process (string/trim (string/join "\n" txt)))]
+              (recur nil 0 (rest lines) (conj (pop out) (str (peek out) s (first lines)))))
+            (let [i (if-not (empty? txt) i (count (re-find pad line)))]
+              (recur (conj txt (unpad line i)) i lines out))))))))
+
+(defn ->cljs-str [s]
+  (if (not= \< (first (string/trim s)))
+    s
+    (tags/parse-string (inline-code s tags/html-escape))))
+
+(defn output-path [forms] (-> forms first second str))
+(defn output-path-for [path] (-> path slurp ->cljs-str output-path))
+
+(defn make-nsdecl [[_ ns-sym & forms] {:keys [refers]}]
+  (let [ns-sym    (symbol ns-sym)
+        core-ns   '#{hoplon.core javelin.core}
+        refers    (if-not refers (conj core-ns 'hoplon.jquery) (set/union core-ns refers))
+        rm?       #{} ;;#(or (contains? refers %) (and (seq %) (contains? refers (first %))))
+        mk-req    #(remove nil? (concat (remove rm? %2) (map %1 refers (repeat %3))))
+        clauses   (->> (tree-seq seq? seq forms) (filter seq?) (group-by first))
+        exclude   (when-let [e (:refer-hoplon clauses)] (nth (first e) 2))
+        combine   #(mapcat (partial drop 1) (% clauses))
+        req       (combine :require)
+        reqm      (combine :require-macros)
+        reqs      `(:require ~@(mk-req refer/make-require req exclude))
+        macros    `(:require-macros ~@(mk-req refer/make-require-macros reqm exclude))
+        other?    #(-> #{:require :require-macros :refer-hoplon}
+                       ((comp not contains?) (first %)))
+        others    (->> forms (filter list?) (filter other?))]
+    `(~'ns ~ns-sym ~@others ~reqs ~macros)))
+
+(defn forms-str [ns-form body]
+  (str (binding [*print-meta* true] (pr-str ns-form)) body))
+
+(defn ns->path [ns]
+  (-> ns munge (string/replace \. \/) (str ".cljs")))
+
+(defn html-str [js-uri]
+  (tags/print-page
+    "html"
+    `(~'html {}
+             (~'head {} (~'meta {:charset "utf-8"}))
+             (~'body {} (~'script {:type "text/javascript"
+                                   :src ~(str js-uri)})))))
+
+(defn compile-forms [nsdecl body {:keys [bust-cache refers] :as opts}]
+  (case (first nsdecl)
+    ns   {:cljs (forms-str (make-nsdecl nsdecl opts) body) :ns (second nsdecl)}
+    page (let [[_ page & _] nsdecl
+               outpath     (output-path [nsdecl])
+               page-ns     (munge-page page)
+               cljsstr     (let [[h _ & t] (make-nsdecl nsdecl opts)]
+                             (forms-str (list* h page-ns t) body))
+               js-out      (if-not bust-cache outpath (hl/bust-cache outpath))
+               js-uri      (-> js-out (string/split #"/") last (str ".js"))
+               htmlstr     (html-str js-uri)
+               ednstr      (pr-str {:require  [(symbol page-ns)]})]
+           {:html htmlstr :edn ednstr :cljs cljsstr :ns page-ns :file outpath :js-file js-out})))
+
+(defn pp [form] (pp/write form :dispatch pp/code-dispatch))
+
+(defn- write [f s]
+  (when (and f s)
+    (doto f io/make-parents (spit s))))
+
+(defn compile-string
+  [say-it forms-as-str path cljsdir htmldir & {{:keys [bust-cache refers] :as opts} :opts}]
+  (let [[[tag ns-sym & clauses :as ns-form] body] (read-string-1 (->cljs-str forms-as-str))
+        {html-path :hoplon/page} (meta ns-sym)]
+    (cond (.endsWith path ".cljs")
+          (let [gen-html? #(= :page (first %))
+                html-cls  (->> clauses (filter gen-html?) first)
+                html-path (or html-path (second html-cls))]
+            (when html-path
+              (let [outpath   (if-not bust-cache html-path (hl/bust-cache html-path))
+                    js-uri    (-> outpath (string/split #"/") last (str ".js"))
+                    edn-path  (str outpath ".cljs.edn")]
+                (say-it outpath)
+                (write (io/file htmldir html-path) (html-str js-uri))
+                (write (io/file cljsdir edn-path) (pr-str {:require [ns-sym]})))))
+          (.endsWith path ".hl")
+          (let [{:keys [cljs ns html edn file js-file]} (compile-forms ns-form body opts)
+                cljs-out (io/file cljsdir (ns->path ns))]
+            (write cljs-out cljs)
+            (when file
+              (let [html-out (io/file htmldir file)
+                    edn-out  (io/file cljsdir (str js-file ".cljs.edn"))]
+                (say-it file)
+                (write edn-out edn)
+                (write html-out html)))))))
+
+(defn compile-file [say-it path & args]
+  (apply compile-string say-it (slurp (io/resource path)) path args))

--- a/src/hoplon/boot_hoplon/impl.clj
+++ b/src/hoplon/boot_hoplon/impl.clj
@@ -1,0 +1,52 @@
+(ns hoplon.boot-hoplon.impl
+  (:require
+    [boot.util                              :as util]
+    [clojure.pprint                         :as pp]
+    [clojure.java.io                        :as io]
+    [clojure.string                         :as string]
+    [clojure.java.shell                     :as sh]
+    [hoplon.boot-hoplon.compiler :as hl]
+    [hoplon.boot-hoplon.tagsoup  :as ts]))
+
+(defn prerender [engine output-dir render-js-path html-files]
+  (let [win?      (#{"Windows_NT"} (System/getenv "OS"))
+        phantom?  (= 0 (:exit (sh/sh (if win? "where" "which") engine)))
+        phantom!  #(let [{:keys [exit out err]} (sh/sh engine %1 %2)
+                         warn? (and (zero? exit) (not (empty? err)))]
+                    (when warn? (println (string/trimr err)))
+                    (if (= 0 exit) out (throw (Exception. err))))
+        doing-it  (delay (util/info "Prerendering HTML files...\n"))
+        not-found #(util/info "Skipping prerender: %s not found on path.\n" engine)]
+    (if (not phantom?)
+      (do (not-found) identity)
+      (doseq [[out-path in-path] html-files]
+        @doing-it
+        (let [->frms #(-> % ts/parse-page ts/pedanticize)
+              forms1 (-> in-path slurp ->frms)
+              forms2 (-> (phantom! render-js-path in-path) ->frms)
+              [_ att1 [_ hatt1 & head1] [_ batt1 & body1]] forms1
+              [html* att2 [head* hatt2 & head2] [body* batt2 & body2]] forms2
+              script? (comp (partial = 'script) first)
+              rm-scripts #(remove script? %)
+              att (merge att1 att2)
+              hatt (merge hatt1 hatt2)
+              head (concat head1 (rm-scripts head2))
+              batt (merge batt1 batt2)
+              body (concat (rm-scripts body2) body1)
+              merged `(~'html ~att (~'head ~hatt ~@head) (~'body ~batt ~@body))
+              prerendered-path (io/file output-dir out-path)]
+          (util/info "• %s\n" out-path)
+          (io/make-parents prerendered-path)
+          (spit prerendered-path (ts/print-page "html" merged)))))))
+
+(defn hoplon [cljs-dir html-dir paths opts]
+  (let [desc    (delay (util/info "Writing HTML files...\n"))
+        say-it  (fn [path] @desc (util/info "• %s\n" path))]
+    (doseq [path paths]
+      (hl/compile-file say-it path (io/file cljs-dir) (io/file html-dir) :opts opts))))
+
+(defn html2cljs [file]
+  (->> file slurp hl/->cljs-str
+       (#(with-out-str (pp/write % :dispatch pp/code-dispatch)))
+       clojure.string/trim
+       (#(subs % 1 (dec (count %))))))

--- a/src/hoplon/boot_hoplon/kahn.clj
+++ b/src/hoplon/boot_hoplon/kahn.clj
@@ -1,0 +1,38 @@
+(ns hoplon.boot-hoplon.kahn
+  (:refer-clojure :exclude [sort])
+  (:require [clojure.set :refer [difference union intersection]]))
+
+(defn choose
+  "Returns the pair [element, s'] where s' is set s with element removed."
+  [s] {:pre [(not (empty? s))]}
+  (let [item (first s)]
+    [item (disj s item)]))
+
+(defn no-incoming
+  "Returns the set of nodes in graph g for which there are no incoming
+  edges, where g is a map of nodes to sets of nodes."
+  [g]
+  (let [nodes (set (keys g))
+        have-incoming (apply union (vals g))]
+    (difference nodes have-incoming)))
+
+(defn normalize
+  "Returns g with empty outgoing edges added for nodes with incoming
+  edges only.  Example: {:a #{:b}} => {:a #{:b}, :b #{}}"
+  [g]
+  (let [have-incoming (apply union (vals g))]
+    (reduce #(if (% %2) % (assoc % %2 #{})) g have-incoming)))
+
+(defn sort
+  "Proposes a topological sort for directed graph g using Kahn's
+   algorithm, where g is a map of nodes to sets of nodes. If g is
+   cyclic, returns nil."
+  ([g]
+     (sort (normalize g) [] (no-incoming g)))
+  ([g l s]
+     (if (empty? s)
+       (if (every? empty? (vals g)) l)
+       (let [[n s'] (choose s)
+             m (g n)
+             g' (reduce #(update-in % [n] disj %2) g m)]
+         (recur g' (conj l n) (union s' (intersection (no-incoming g') m)))))))

--- a/src/hoplon/boot_hoplon/pod_deps.edn
+++ b/src/hoplon/boot_hoplon/pod_deps.edn
@@ -1,0 +1,2 @@
+[[clj-tagsoup "0.3.0"]
+ [org.clojure/data.xml "0.0.8"]]

--- a/src/hoplon/boot_hoplon/refer.clj
+++ b/src/hoplon/boot_hoplon/refer.clj
@@ -1,0 +1,179 @@
+;; Copyright (c) Alan Dipert and Micha Niskin. All rights reserved.
+;; The use and distribution terms for this software are covered by the
+;; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;; which can be found in the file epl-v10.html at the root of this distribution.
+;; By using this software in any fashion, you are agreeing to be bound by
+;; the terms of this license.
+;; You must not remove this notice, or any other, from this software.
+
+(ns hoplon.boot-hoplon.refer
+  (:require
+    [cljs.util         :as u]
+    [cljs.analyzer     :as a]
+    [clojure.java.io   :as io]
+    [cljs.analyzer.api :as ana]
+    [clojure.set       :as set]
+    [boot.util         :as util]
+    [clojure.string    :as string]
+    [hoplon.boot-hoplon.kahn :as kahn])
+  (:import
+    [java.io StringReader]
+    [clojure.lang LineNumberingPushbackReader]))
+
+(def ^:dynamic *in-ns* nil)
+
+(def st (ana/empty-state))
+
+(defn read-string-1
+  [x]
+  (when x
+    (with-open [r (LineNumberingPushbackReader. (StringReader. x))]
+      [(read r false nil)
+       (apply str (concat (repeat (dec (.getLineNumber r)) "\n") [(slurp r)]))])))
+
+(defn forms-str [ns-form body]
+  (str (binding [*print-meta* true] (pr-str ns-form)) body))
+
+(defn analyze [ns]
+  (try (ana/analyze-file (u/ns->relpath ns :cljs))
+       (catch Throwable _ (ana/analyze-file (u/ns->relpath ns :cljc)))))
+
+(defn require* [ns]
+  (try (require ns) true (catch Throwable _)))
+
+(def macro?       (comp (some-fn :macro (comp :macro meta)) second))
+(def type?        (comp (some-fn :type :record) second))
+(def protocol?    (comp (some-fn :protocol :protocol-info :protocol-symbol) :meta second))
+(def without-meta (comp (partial apply with-meta) (partial conj '(nil))))
+(def public-names (comp (partial map (comp without-meta first)) sort))
+
+(defn get-publics [ns]
+  (binding [a/*analyze-deps* false
+            a/*cljs-warnings* nil]
+    (let [macros (filter macro? (and (require* ns) (ns-publics ns)))
+          defs   (try (when-not (= ns *in-ns*)
+                        (ana/with-state st
+                          (do (analyze ns)
+                              (->> (ana/ns-publics ns)
+                                   (remove (some-fn protocol? type? macro?))))))
+                      (catch Throwable _))]
+      {:macros (public-names macros) :defs (public-names defs)})))
+
+(defn exclude [ops exclusions]
+  (vec (set/difference (set ops) (set exclusions))))
+
+(defn make-require [ns-sym & [exclusions]]
+  (when-let [refers (exclude (:defs (get-publics ns-sym)) exclusions)]
+    [ns-sym :refer (vec refers)]))
+
+(defn make-require-macros [ns-sym & [exclusions]]
+  (when-let [refers (seq (exclude (:macros (get-publics ns-sym)) exclusions))]
+    [ns-sym :refer (vec refers)]))
+
+(defn expand-nested [[ns-sym & args :as spec]]
+  (letfn [(combine [[ns-sym' & args]]
+            `[~(symbol (str ns-sym "." ns-sym')) ~@args])]
+    (if-not (and args (every? vector? args))
+      [spec]
+      (vec (->> (map combine args) (mapcat expand-nested))))))
+
+(defn do-require [xs [ns & mods]]
+  (let [{:keys [defs macros]} (get-publics ns)
+        [defs macros] (map set [defs macros])
+        mods          (apply hash-map mods)
+        [names mods]  ((juxt #(% :refer) #(dissoc % :refer)) mods)
+        names         (if (= names :all) (set/union defs macros) (set names))
+        refer-defs    (set/intersection defs names)
+        refer-macros  (set/intersection macros names)
+        refer-errors  (set/difference names (set/union defs macros))
+        inset         (fnil into #{})
+        xs (if (empty? defs) xs (update-in xs [:require ns] merge mods))
+        xs (if (empty? macros) xs (update-in xs [:require-macros ns] merge mods))
+        xs (if (empty? refer-defs) xs (update-in xs [:require ns :refer] inset refer-defs))
+        xs (if (empty? refer-macros) xs (update-in xs [:require-macros ns :refer] inset refer-macros))]
+    (doseq [x (set/intersection defs macros)]
+      (util/warn "WARNING: Name conflict, %s/%s is both CLJS var and CLJ macro.\n" ns x))
+    (doseq [x (set/difference names (set/union defs macros))]
+      (util/warn "WARNING: Can't :refer %s/%s because it doesn't exist.\n" ns x))
+    xs))
+
+(defn do-use [xs [ns & mods]]
+  (let [{:keys [defs macros]} (get-publics ns)
+        [defs macros] (map set [defs macros])
+        all-names     (set/union defs macros)
+        mods          (apply hash-map mods)
+        [only excl mods] ((juxt #(% :only) #(% :exclude) #(dissoc % :only :exclude)) mods)
+        names         (cond (seq only) (set only)
+                            (seq excl) (set/difference all-names (set excl))
+                            :else      all-names)]
+    (do-require xs (into [ns] (mapcat identity (assoc mods :refer (vec names)))))))
+
+(defn parse-spec [xs [ns-sym & args]]
+  (update-in xs [ns-sym] merge (apply hash-map args)))
+
+(defn parse-clause [xs [k & specs]]
+  (case k
+    (:require-macros :use-macros)
+    (merge-with merge xs {k (reduce parse-spec {} (mapcat expand-nested specs))})
+    (assoc xs k (vec specs))))
+
+(defn parse-nsdecl [[tag ns-sym & clauses]]
+  (binding [*in-ns* ns-sym]
+    (merge {:tag tag :ns-sym ns-sym}
+           {:clauses (let [{:keys [require use] :as ret} (reduce parse-clause {} clauses)]
+                       (reduce do-use (reduce do-require (dissoc ret :require :use) require) use))})))
+
+(defn emit-spec [[ns-sym mods]]
+  (into [ns-sym] (mapcat (fn [[k v]] [k (if (set? v) (vec (sort v)) v)]) mods)))
+
+(defn emit-clause [[k specs]]
+  (if-not (map? specs)
+    (list* k specs)
+    (list* k (map emit-spec specs))))
+
+(defn emit-nsdecl [{:keys [tag ns-sym clauses]}]
+  (list* tag ns-sym (map emit-clause (into (sorted-map) clauses))))
+
+(defn rewrite-ns-form [ns-form]
+  (emit-nsdecl (parse-nsdecl ns-form)))
+
+(defn get-cljs-deps [ns-path]
+  (some->> (io/resource ns-path)
+           (slurp)
+           (read-string)
+           (drop 2)
+           (filter (comp #{:require :use} first))
+           (mapcat (comp (partial map #(if (symbol? %) % (first %))) (partial drop 1)))
+           (filter #(= "file" (some-> % u/ns->source .getProtocol)))
+           (keep #(let [p (u/ns->relpath %)] (when (not= p ns-path) p)))
+           (into #{})))
+
+(defn sort-dep-order [paths]
+  (let [p (set paths)]
+    (loop [[path & paths] paths graph {}]
+      (if-not path
+        (->> (kahn/sort graph) (reverse) (filter p))
+        (let [deps (get-cljs-deps path)]
+          (recur (into paths deps) (assoc graph path deps)))))))
+
+(def valid-clause?
+  (comp #{:refer-clojure :require :require-macros :use :use-macros :import} first))
+
+(defn rewrite-ns-path [say-it modtime outdir path]
+  (let [[[tag ns-sym & clauses] body] (read-string-1 (slurp (io/resource path)))]
+    (when (= tag 'ns+)
+      (say-it path)
+      (let [ns-form (list* 'ns ns-sym (filter valid-clause? clauses))
+            outfile (doto (io/file outdir path) io/make-parents)]
+        (->> (forms-str (rewrite-ns-form ns-form) body) (spit outfile))
+        (.setLastModified outfile modtime)))))
+
+(comment
+
+  (->> (rewrite-ns-form
+         '(ns foo.bar
+            (:require [javelin.core :refer :all]
+                      [hoplon.core :refer [p h1 h3 h2]])))
+       (clojure.pprint/pprint))
+
+  )

--- a/src/hoplon/boot_hoplon/tagsoup.clj
+++ b/src/hoplon/boot_hoplon/tagsoup.clj
@@ -1,0 +1,106 @@
+;; Copyright (c) Alan Dipert and Micha Niskin. All rights reserved.
+;; The use and distribution terms for this software are covered by the
+;; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;; which can be found in the file epl-v10.html at the root of this distribution.
+;; By using this software in any fashion, you are agreeing to be bound by
+;; the terms of this license.
+;; You must not remove this notice, or any other, from this software.
+
+(ns hoplon.boot-hoplon.tagsoup
+  (:refer-clojure :exclude [replace])
+  (:require
+    [pl.danieljanus.tagsoup :as ts]
+    [clojure.pprint         :as pp :refer [pprint]]
+    [clojure.string         :as cs :refer [blank? replace replace-first split join]]
+    [clojure.walk           :as cw :refer [postwalk]]))
+
+(def cljs-attr? #(and (string? %) (re-find #"^\s*\{\{.*\}\}\s*" %)))
+(def walk-attr  #(if-not (cljs-attr? %) % (-> % (replace #"^\s*\{\{\s*" "")
+                                            (replace #"\s*\}\}\s*$" "")
+                                            read-string)))
+
+(defn split-ns [x]
+  (let [[_ ns? & _ :as p] (split (name x) #"\.")]
+    [(when ns? (join "." (butlast p))) (last p)]))
+
+(defn ns-keys [attr]
+  (into {} (for [[k v] attr] [(apply keyword (split-ns k)) v])))
+
+(defn parse-hiccup [x]
+  (if (string? x)
+    x
+    (let [[tag attr & kids] x]
+      (list*
+        (apply symbol (split-ns tag))
+        (concat
+          (if (empty? attr) (list) (list (ns-keys attr)))
+          (map parse-hiccup kids))))))
+
+(defn collapse [x]
+  (if (string? x)
+    x
+    (let [[tag attr & kids] x
+          ws? #(and (string? %) (blank? %))]
+      (into [tag attr] (map collapse (if (= :pre tag) kids (remove ws? kids)))))))
+
+(defn read-hiccup [s]
+  (collapse (ts/parse-string s :strip-whitespace false)))
+
+(defn parse-snip [s]
+  (let [[html attr body] (read-hiccup s)]
+    (parse-hiccup (nth body 2))))
+
+(defn parse-page [s]
+  (parse-hiccup (read-hiccup s)))
+
+(defn parse-string [s]
+  (let [hiccup  (read-hiccup s)
+        prelude (read-string (str "(" (-> hiccup (nth 2) (nth 2)) "\n)"))]
+    (concat prelude (list (parse-hiccup (postwalk walk-attr (nth hiccup 3)))))))
+
+(defn parse [f]
+  (parse-string (slurp f)))
+
+(defn pedanticize [form]
+  (cond (string? form) (list '$text form)
+        (symbol? form) (list form {})
+        (seq? form)
+        (let [[tag & tail] form]
+          (if (or (= '$text tag) (= '$comment tag))
+            form
+            (let [attr (if (map? (first tail)) (first tail) {})
+                  kids (map pedanticize (if (map? (first tail)) (rest tail) tail))]
+              (list* tag attr kids))))))
+
+(def void-elems
+  #{'area     'base     'br       'col      'embed    'hr       'img    'input
+    'keygen   'link     'menuitem 'meta     'param    'source   'track  'wbr})
+
+(defn attr->string [attr]
+  (->> (for [[k v] attr]
+         (str (name k) "=" (pr-str (if (string? v) v (str "{{ " v " }}")))))
+       (cons "")
+       (interpose " ")
+       (apply str)))
+
+(defn html-escape [s]
+  (-> s (replace #"&" "&amp;") (replace #"<" "&lt;") (replace #">" "&gt;")))
+
+(defn hoplon->string* [[tag attr & kids :as form]]
+  (case tag
+    $text     (html-escape attr)
+    $comment  (str "<!-- " attr " -->")
+    (let [attr (attr->string attr)
+          kids (->> kids (map hoplon->string*) (apply str))]
+      (if (void-elems tag)
+        (str "<" tag attr ">")
+        (str "<" tag attr ">" kids "</" tag ">")))))
+
+(defn print-string [form]
+  (hoplon->string* (pedanticize form)))
+
+(defn print-page [doctype forms]
+  (str "<!DOCTYPE " doctype ">\n" (print-string forms)))
+
+(defn parse-map [{:keys [tag attrs content]}]
+  (list* (apply symbol (split-ns tag)) (postwalk walk-attr (or attrs {})) content))

--- a/src/hoplon/boot_hoplon/util.clj
+++ b/src/hoplon/boot_hoplon/util.clj
@@ -1,0 +1,18 @@
+(ns hoplon.boot-hoplon.util
+  (:refer-clojure :exclude [read-string])
+  (:require
+   [clojure.string :as string]))
+
+(defn get-aliases [forms-str]
+  (->> forms-str
+    clojure.core/read-string
+    (filter sequential?)
+    (group-by first)
+    :require
+    (mapcat rest)
+    (filter sequential?)
+    (map (juxt #(second (drop-while (partial not= :as) %)) first))
+    (into {})))
+
+(defn get-ns [forms-str]
+  (->> forms-str clojure.core/read-string second munge-page))

--- a/src/hoplon/core.clj
+++ b/src/hoplon/core.clj
@@ -16,6 +16,14 @@
 
 (create-ns 'js)
 
+(try (let [env  @(do (require 'boot.pod) (resolve 'boot.pod/env))
+           fail @(do (require 'boot.util) (resolve 'boot.util/fail))]
+       (when-let [dep (some-> (->> env (:dependencies) (group-by first))
+                              (get 'hoplon/boot-hoplon) (first) (pr-str))]
+         (fail "The boot-hoplon dependency has been incorporated into hoplon and is no longer needed.\n")
+         (fail "Please remove %s from your :dependencies.\n" dep)))
+     (catch Throwable _))
+
 ;;-- helpers ----------------------------------------------------------------;;
 
 (defn subs [& args] (try (apply clojure.core/subs args) (catch Throwable _)))


### PR DESCRIPTION
- Merge boot-hoplon back into hoplon. This eliminates issues associated
  with using an older version of boot-hoplon with a newer version of
  hoplon. The boot-hoplon dependency is now deprecated and should not be
  used.
- Print a warning when boot-hoplon dependency was specified.
- Make clojure and clojurescript dependencies scope "compile" instead of
  "provided": this will help the user more easily see the dependencies
  in case of conflicts so they can debug and fix. With scope "provided"
  these dependencies are not shown in the dependency graph or the list
  of conflicts when building a project that depends on hoplon, so it's
  more difficult to debug dependency issues.
