### PR TITLE
Parse args should recur if the current or remaining args are non-nil

### DIFF
--- a/src/hoplon/core.cljs
+++ b/src/hoplon/core.cljs
@@ -286,7 +286,7 @@
   (loop [attr (transient {})
          kids (transient [])
          [arg & args] args]
-    (if-not arg
+    (if-not (or arg args)
       [(persistent! attr) (persistent! kids)]
       (cond (map? arg)       (recur (reduce-kv #(assoc! %1 %2 %3) attr arg) kids args)
             (attribute? arg) (recur (assoc! attr arg (first args)) kids (rest args))


### PR DESCRIPTION
Fixes #159 

It might read better now as an if instead of if-not, as follows, but I figured I keep the change as small as possible.
```
(if (or arg args)
      (cond (map? arg)       (recur (reduce-kv #(assoc! %1 %2 %3) attr arg) kids args)
            (attribute? arg) (recur (assoc! attr arg (first args)) kids (rest args))
            (seq?* arg)      (recur attr (reduce conj! kids (flatten arg)) args)
            (vector?* arg)   (recur attr (reduce conj! kids (flatten arg)) args)
            :else            (recur attr (conj! kids arg) args))
      [(persistent! attr) (persistent! kids)])
```