### PR TITLE
Let appendChild support moving nodes

### DIFF
--- a/src/hoplon/core.cljs
+++ b/src/hoplon/core.cljs
@@ -136,6 +136,8 @@
         (fn [x]
           (this-as this
             (with-let [x x]
+              (when (.-parentNode x)
+                (.removeChild (.-parentNode x) x))
               (ensure-kids! this)
               (let [kids (kidfn this)
                     i    (count @kids)]


### PR DESCRIPTION
If the child already has a parent it needs to be removed from that parent before being appended to the new one.

This fixes a problem I ran into trying to use blockly with hoplon.

```
  // Move the selected block to the top of the stack.
  var block = this;
  do {
    var root = block.getSvgRoot();
    root.parentNode.appendChild(root);
    block = block.getParent();
  } while (block);
```