### PR TITLE
221

### DIFF
--- a/src/hoplon/core.cljs
+++ b/src/hoplon/core.cljs
@@ -414,16 +414,16 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; HTML Constructors ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-(defn- mksingleton
-  [elem]
-  (fn [& args]
-   (with-let [elem elem]
-    (let [[attrs kids] (parse-args args)
-          elem (->hoplon elem)]
-     (add-attributes! elem attrs)
-     (when-not (:static attrs)
-       (merge-kids elem nil nil)
-       (add-children! elem kids))))))
+(defn- update-singleton!
+ [elem args]
+ (with-let [elem elem]
+  (let [[attrs kids] (parse-args args)
+        elem (->hoplon elem)]
+   (prn kids (:static attrs))
+   (add-attributes! elem attrs)
+   (when-not (:static attrs)
+    (merge-kids elem nil nil)
+    (add-children! elem kids)))))
 
 (defn- mkelem [tag]
   (fn [& args]
@@ -439,22 +439,22 @@
  (with-let [el (.-documentElement js/document)]
   (add-attributes! (->hoplon el) (first (parse-args args)))))
 
-(def head
+(defn head
  "Updates and returns the document's `head` element in place."
- (mksingleton (.-head js/document)))
+ [& args]
+ (update-singleton! (.-head js/document) args))
 
-(def body
+(defn body
  "Updates and returns the document's `body` element in place. Creates `body`
  if not exists."
- (mksingleton
-  (do
-   ; the body is not always set on the document (e.g. phantomjs tests)
-   (when-not (.-body js/document)
-    ; https://developer.mozilla.org/en-US/docs/Web/API/Document/body
-    (set!
-     (.-body js/document)
-     (.createElement js/document "body")))
-   (.-body js/document))))
+ [& args]
+ ; the body is not always set on the document (e.g. phantomjs tests)
+ (when-not (.-body js/document)
+  ; https://developer.mozilla.org/en-US/docs/Web/API/Document/body
+  (set!
+   (.-body js/document)
+   (.createElement js/document "body")))
+ (update-singleton! (.-body js/document) args))
 
 (def a              (mkelem "a"))
 (def abbr           (mkelem "abbr"))

--- a/src/hoplon/core.cljs
+++ b/src/hoplon/core.cljs
@@ -413,17 +413,7 @@
      (invoke! this a b c d e f g h i j k l m n o p q r s t rest))))
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; HTML Constructors ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-(defn- update-singleton!
- [elem args]
- (with-let [elem elem]
-  (let [[attrs kids] (parse-args args)
-        elem (->hoplon elem)]
-   (add-attributes! elem attrs)
-   (when-not (:static attrs)
-    (merge-kids elem nil nil)
-    (add-children! elem kids)))))
-
+;; HTML Constructor ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defn- mkelem [tag]
   (fn [& args]
     (let [[attr kids] (parse-args args)
@@ -433,15 +423,16 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; HTML Elements ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-(defn html [& args]
+(defn html
  "Updates and returns the document's `html` element in place."
+ [& args]
  (with-let [el (.-documentElement js/document)]
   (add-attributes! (->hoplon el) (first (parse-args args)))))
 
 (defn head
  "Updates and returns the document's `head` element in place."
  [& args]
- (update-singleton! (.-head js/document) args))
+ (apply (.-head js/document) args))
 
 (defn body
  "Updates and returns the document's `body` element in place. Creates `body`
@@ -453,7 +444,7 @@
   (set!
    (.-body js/document)
    (.createElement js/document "body")))
- (update-singleton! (.-body js/document) args))
+ (apply (.-body js/document) args))
 
 (def a              (mkelem "a"))
 (def abbr           (mkelem "abbr"))

--- a/src/hoplon/core.cljs
+++ b/src/hoplon/core.cljs
@@ -419,7 +419,6 @@
  (with-let [elem elem]
   (let [[attrs kids] (parse-args args)
         elem (->hoplon elem)]
-   (prn kids (:static attrs))
    (add-attributes! elem attrs)
    (when-not (:static attrs)
     (merge-kids elem nil nil)

--- a/tst/src/cljs/hoplon/elements_test.cljs
+++ b/tst/src/cljs/hoplon/elements_test.cljs
@@ -50,6 +50,15 @@
   (is (not (h/native-node? e)))
   (is (h/element? e))))
 
+(deftest ??singelton--update
+ (is (not (.webkitMatchesSelector (h/head) "[data-foo]")))
+ (let [el (h/script)]
+  (h/head #{:data-foo} el)
+  (is (.webkitMatchesSelector (h/head) "[data-foo]"))
+  (prn (.-outerHTML (h/head)))
+  (prn (.-outerHTML el))
+  (is (goog.dom/contains (h/head) el))))
+
 (def elements
  [
   [h/a "a"]

--- a/tst/src/cljs/hoplon/elements_test.cljs
+++ b/tst/src/cljs/hoplon/elements_test.cljs
@@ -50,14 +50,18 @@
   (is (not (h/native-node? e)))
   (is (h/element? e))))
 
-(deftest ??singelton--update
+(deftest ??singleton--update
  (is (not (.webkitMatchesSelector (h/head) "[data-foo]")))
  (let [el (h/script)]
   (h/head #{:data-foo} el)
   (is (.webkitMatchesSelector (h/head) "[data-foo]"))
-  (prn (.-outerHTML (h/head)))
-  (prn (.-outerHTML el))
-  (is (goog.dom/contains (h/head) el))))
+  (is (goog.dom/contains (h/head) el)))
+
+ (is (not (.webkitMatchesSelector (h/body) "[data-foo]")))
+ (let [el (h/div)]
+  (h/body #{:data-foo} el)
+  (is (.webkitMatchesSelector (h/body) "[data-foo]"))
+  (is (goog.dom/contains (h/body) el))))
 
 (def elements
  [


### PR DESCRIPTION
fixes #221 by shifting the defensive body creation to when `body` is called rather than when it is defined.

it doesn't make any sense to call `body` in an embedded hoplon setup, so this should be safe for both embedded and normal hoplon.