### PR TITLE
Fix singleton reloading, remove unused merge-kids parameter

### DIFF
--- a/src/hoplon/core.cljs
+++ b/src/hoplon/core.cljs
@@ -50,7 +50,7 @@
           (recur (inc i))))))))
 
 (defn- merge-kids
-  [this _ new]
+  [this new]
   (let [new  (->> (vflatten new) (reduce #(if (nil? %2) %1 (conj %1 %2)) []) (mapv ->node))
         new? (set new)]
     (loop [[x & xs] new
@@ -277,7 +277,7 @@
        (if-let [hl-kids (.-hoplonKids this)] hl-kids
          (with-let [kids (atom (child-vec this))]
            (set! (.-hoplonKids this) kids)
-           (do-watch kids (partial merge-kids this))))))
+           (do-watch kids #(merge-kids this %2))))))
     (-append-child!
       ([this child]
        (with-let [child child]

--- a/src/hoplon/core.cljs
+++ b/src/hoplon/core.cljs
@@ -351,6 +351,9 @@
       (when-let [x (->node x)]
         (-append-child! this x)))))
 
+(defn- remove-all-kids! [this]
+  (swap! (-hoplon-kids this) empty))
+
 (defn- invoke!
   [this & args]
   (let [[attr kids] (parse-args args)]
@@ -425,7 +428,7 @@
      (with-let [helem (->hoplon oelem)]
        (let [[attrs kids] (parse-args args)]
          (when-not (:static attrs)
-           (merge-kids helem nil nil)
+           (remove-all-kids! helem)
            (add-attributes! helem attrs)
            (add-children! helem kids)))))))
 


### PR DESCRIPTION
Fixes #244 and begins to refactor `merge-kids`