### PR TITLE
Improve child-vec, vflatten and loop-tpl

### DIFF
--- a/src/hoplon/core.cljs
+++ b/src/hoplon/core.cljs
@@ -30,11 +30,8 @@
 ;; Internal Helpers ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defn- child-vec
   [this]
-  (let [x (.-childNodes this)
-        l (.-length x)]
-    (loop [i 0 ret (transient [])]
-      (or (and (= i l) (persistent! ret))
-          (recur (inc i) (conj! ret (.item x i)))))))
+  (let [x (.-childNodes this)]
+    (areduce x i ret [] (conj ret (.item x i)))))
 
 (defn- vflatten
   "Takes a sequential collection and returns a flattened vector of any nested

--- a/src/hoplon/core.cljs
+++ b/src/hoplon/core.cljs
@@ -36,8 +36,8 @@
 (defn- vflatten
   "Takes a sequential collection and returns a flattened vector of any nested
   sequential collections."
-  ([x] (vflatten [] x))
-  ([acc x] (if (sequential? x) (reduce vflatten acc x) (conj acc x))))
+  ([x] (persistent! (vflatten (transient []) x)))
+  ([acc x] (if (sequential? x) (reduce vflatten acc x) (conj! acc x))))
 
 (defn- remove-nil [nodes]
   (reduce #(if %2 (conj %1 %2) %1) [] nodes))

--- a/src/hoplon/core.cljs
+++ b/src/hoplon/core.cljs
@@ -638,23 +638,13 @@
   removed from the DOM and cached. When the items collection grows again those
   cached elements will be reinserted into the DOM at their original index."
   [items tpl]
-  (let [on-deck   (atom ())
-        items-seq (cell= (seq items))
-        ith-item  #(cell= (nth items-seq % nil))
-        shift!    #(with-let [x (first @%)] (swap! % rest))]
-    (with-let [current (cell [])]
-      (do-watch items-seq
-        (fn [old-items new-items]
-          (let [old  (count old-items)
-                new  (count new-items)
-                diff (- new old)]
-            (cond (pos? diff)
-                  (doseq [i (range old new)]
-                    (let [e (or (shift! on-deck) (tpl (ith-item i)))]
-                      (swap! current conj e)))
-                  (neg? diff)
-                  (dotimes [_ (- diff)]
-                    (let [e (peek @current)]
-                      (swap! current pop)
-                      (swap! on-deck conj e))))))))))
+  (let [els         (cell [])
+        itemsv      (cell= (vec items))
+        items-count (cell= (count items))]
+    (do-watch items-count
+              (fn [_ n]
+                (when (< (count @els) n)
+                  (doseq [i (range (count @els) n)]
+                    (swap! els assoc i (tpl (cell= (get itemsv i nil))))))))
+    (cell= (subvec els 0 (min items-count (count els))))))
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/hoplon/core.cljs
+++ b/src/hoplon/core.cljs
@@ -37,14 +37,10 @@
           (recur (inc i) (conj! ret (.item x i)))))))
 
 (defn- vflatten
-  ([tree]
-   (persistent! (vflatten tree (transient []))))
-  ([tree ret]
-   (loop [[x & rst] tree]
-     (if (sequential? x)
-       (when (seq x) (vflatten x ret)) ;;edit: remove empty lists
-       (conj! ret x))
-     (if-not rst ret (recur rst)))))
+  "Takes a sequential collection and returns a flattened vector of any nested
+  sequential collections."
+  ([x] (vflatten [] x))
+  ([acc x] (if (sequential? x) (reduce vflatten acc x) (conj acc x))))
 
 (defn- remove-nil [nodes]
   (reduce #(if %2 (conj %1 %2) %1) [] nodes))


### PR DESCRIPTION
These are all changes which in my opinion improve the readability of the code somewhat and in addition provide some measurable performance benefit (in both extensive contrived benchmarks and real projects).

The major question here is whether to use transients or not in `vflatten` and `child-vec`. Transients add some overhead which make the operation slower on very small lists than a non-transient version. 

Ultimately I left the transient in `vflatten` and removed it from `child-vec`. The transient version of `child-vec` only starts to outperform the non-transient version after there are 8-10 children, and some quick research into average number of dom children per element yields a number much lower than that. `vflatten` is a closer call so I left it in. 

I think both these decisions don't matter much. With or without transients both of the new implementations are definitely faster than the current ones with all inputs I tried. 