### PR TITLE
fix default attribute handling

### DIFF
--- a/src/hoplon/core.cljs
+++ b/src/hoplon/core.cljs
@@ -428,8 +428,8 @@
 (defmulti do! ns-dispatcher :default ::default)
 
 (defmethod do! ::default
-  [elem key kvs]
-  (set-attributes! elem kvs))
+  [elem k v]
+  (set-attributes! elem k v))
 
 (defmethod do! ::attr
   [elem key kvs]


### PR DESCRIPTION
`do!` takes a key and value pair, which should be passed to `set-attributes!` directly.