### PR TITLE
Singletons should replace children on reset

### DIFF
--- a/src/hoplon/core.cljs
+++ b/src/hoplon/core.cljs
@@ -398,6 +398,7 @@
   [elem key val]
   (with-let [elem elem]
     (let [kids (-hoplon-kids elem)]
+      (swap! kids empty)
       (doseq [w (keys (.-watches kids))]
         (remove-watch kids w))
       (set! (.-hoplonKids elem) val))))

--- a/src/hoplon/core.cljs
+++ b/src/hoplon/core.cljs
@@ -534,8 +534,9 @@
 ;; HTML Elements ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defn html [& args]
  "Updates and returns the document's `html` element in place."
- (let [elem (mksingleton "documentElement")]
-   (elem (first (parse-args args)))))
+  (let [elem (mksingleton "documentElement")
+        [attr kids] (parse-args args)]
+   (elem kids)))
 
 (def head
  "Updates and returns the document's `head` element in place."


### PR DESCRIPTION
Singletons (`html`, `head` and `body`) should completely replace the existing element in the document when they are called. Without this PR, children are just being appended to the element instead of replacing the current children. 

Fixes #264