### PR TITLE
listen event throws "invalid event type" under advanced compilation when using google attributes provider

### DIFF
--- a/src/hoplon/goog.cljs
+++ b/src/hoplon/goog.cljs
@@ -117,6 +117,5 @@
 ;; Google Closure Library Events ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defmethod on! :hoplon.core/default
   [elem event callback]
-  (let [event (obj/get events/EventType (.toUpperCase (name event)))]
-    (events/listen elem event callback)))
+  (events/listen elem (name event) callback))
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
 [FIX] (google attributes provider):  pass directly the name of the event since goog.events.EventType keys are renamed in advanced compilation