### PR TITLE
Use Element.matches()

### DIFF
--- a/tst/src/cljs/hoplon/class_test.cljs
+++ b/tst/src/cljs/hoplon/class_test.cljs
@@ -20,22 +20,22 @@
 
 (deftest ??class
  (let [el (h/div :class "foo")]
-  (is (.webkitMatchesSelector el ".foo"))
+  (is (.matches el ".foo"))
 
   (el :class "bar")
-  (is (.webkitMatchesSelector el ".foo.bar"))
+  (is (.matches el ".foo.bar"))
 
   (el :class/baz "baz")
-  (is (.webkitMatchesSelector el ".foo.bar.baz"))
+  (is (.matches el ".foo.bar.baz"))
 
   (el :class {"foo" false
               "baz" false
               "bar" true})
-  (is (.webkitMatchesSelector el ".bar"))
-  (is (not (.webkitMatchesSelector el ".foo")))
-  (is (not (.webkitMatchesSelector el ".baz"))))
+  (is (.matches el ".bar"))
+  (is (not (.matches el ".foo")))
+  (is (not (.matches el ".baz"))))
 
- (is (.webkitMatchesSelector
+ (is (.matches
       (h/div
        :class #{"foo" "bar"}
        :class/baz "baz"
@@ -43,10 +43,10 @@
       ".foo.bar.baz.bing")))
 
 (deftest ??class--extend
- (is (.webkitMatchesSelector
+ (is (.matches
       (extended-el :class "bing")
       "div.foo.bar.bing"))
 
- (is (.webkitMatchesSelector
+ (is (.matches
       (extended-el :class/extend "baz")
       "div.foo.baz:not(.bar)")))

--- a/tst/src/cljs/hoplon/defattr_test.cljs
+++ b/tst/src/cljs/hoplon/defattr_test.cljs
@@ -9,4 +9,4 @@
 
 (deftest ??defattr
  (let [el (h/div :baz true)]
-  (is (.webkitMatchesSelector el "div[baz]"))))
+  (is (.matches el "div[baz]"))))

--- a/tst/src/cljs/hoplon/defelem_test.cljs
+++ b/tst/src/cljs/hoplon/defelem_test.cljs
@@ -34,14 +34,14 @@
 
 (deftest ??divs
  ; trivial case
- (is (.webkitMatchesSelector (div--basic) "div"))
+ (is (.matches (div--basic) "div"))
 
  ; attribute arguments
- (is (.webkitMatchesSelector (div--attributes :data-foo true) "div[data-foo]"))
+ (is (.matches (div--attributes :data-foo true) "div[data-foo]"))
 
  ; destructuring attributes
- (is (.webkitMatchesSelector (div--destructured :foo "123" :data-baz "456") "div[data-bar=\"123\"][data-baz=\"456\"]"))
- (is (.webkitMatchesSelector (div--destructured-attributes-only :foo "123" :data-baz "456") "div[data-bar=\"123\"][data-baz=\"456\"]"))
+ (is (.matches (div--destructured :foo "123" :data-baz "456") "div[data-bar=\"123\"][data-baz=\"456\"]"))
+ (is (.matches (div--destructured-attributes-only :foo "123" :data-baz "456") "div[data-bar=\"123\"][data-baz=\"456\"]"))
 
  (doseq [el [; children arguments
              (div--children (h/span) (h/p))

--- a/tst/src/cljs/hoplon/elements_test.cljs
+++ b/tst/src/cljs/hoplon/elements_test.cljs
@@ -25,7 +25,7 @@
                 [(.-body js/document) "body"]
                 [(.-documentElement js/document) "html"]]]
   (is (goog.dom/isElement e))
-  (is (.webkitMatchesSelector e s))
+  (is (.matches e s))
   (is (h/native? e))
   (is (h/native-node? e))
   (is (not (h/element? e)))))
@@ -36,7 +36,7 @@
                 [(h/body) "body"]
                 [(h/html) "html"]]]
   (is (goog.dom/isElement e))
-  (is (.webkitMatchesSelector e s))
+  (is (.matches e s))
   (is (not (h/native? e)))
   (is (not (h/native-node? e)))
   (is (h/element? e))))
@@ -47,7 +47,7 @@
                 [(.-body js/document) "body"]
                 [(.-documentElement js/document) "html"]]]
   (is (goog.dom/isElement e))
-  (is (.webkitMatchesSelector e s))
+  (is (.matches e s))
   (is (not (h/native? e)))
   (is (not (h/native-node? e)))
   (is (h/element? e))))
@@ -58,7 +58,7 @@
                 [(h/body :hoplon/static true) "body"]
                 [(h/html :hoplon/static true) "html"]]]
   (is (goog.dom/isElement e))
-  (is (.webkitMatchesSelector e s))
+  (is (.matches e s))
   (is (not (h/native? e)))
   (is (not (h/native-node? e)))
   (is (h/element? e))))
@@ -182,8 +182,8 @@
    (is (goog.dom/isElement hoplon-el))
    (is (goog.dom/isElement native-el))
 
-   (is (.webkitMatchesSelector hoplon-el s) (str "Element did not match selector: " s))
-   (is (.webkitMatchesSelector native-el s) (str "Element did not match selector: " s))
+   (is (.matches hoplon-el s) (str "Element did not match selector: " s))
+   (is (.matches native-el s) (str "Element did not match selector: " s))
 
    (is (not (hoplon.core/native? hoplon-el)))
    (is (hoplon.core/native? native-el))
@@ -224,14 +224,14 @@
   (doseq [e [(el-fn #{:data-foo})
              (el-fn :data-foo true)
              (el-fn {:data-foo true})]]
-   (is (.webkitMatchesSelector e "[data-foo=\"data-foo\"]")))
+   (is (.matches e "[data-foo=\"data-foo\"]")))
 
   ; setting a specific cljs value (such as a keyword) for "data-foo"
   (doseq [e [(el-fn :data-foo :data-foo)
              (el-fn {:data-foo :data-foo})]]
-   (is (.webkitMatchesSelector e "[data-foo=\":data-foo\"]")))
+   (is (.matches e "[data-foo=\":data-foo\"]")))
   ; ability to set "true" is important for some HTML APIs, e.g. "draggable" for
   ; HTML5 drag and drop.
-  (is (.webkitMatchesSelector
+  (is (.matches
        (el-fn {:data-foo "true"})
        "[data-foo=\"true\"]"))))

--- a/tst/src/cljs/hoplon/protocol_test.cljs
+++ b/tst/src/cljs/hoplon/protocol_test.cljs
@@ -5,12 +5,12 @@
 
 (deftest ??element-IFn
  (let [el (h/div :class "foo" (h/p))]
-  (is (.webkitMatchesSelector el "div.foo"))
+  (is (.matches el "div.foo"))
   (is (.querySelector el "p"))
 
   ; the el itself should act as a fn that accepts attributes and children
   (el (h/span) :class "bar")
-  (is (.webkitMatchesSelector el "div.foo.bar"))
+  (is (.matches el "div.foo.bar"))
   (is (.querySelector el "p"))
   (is (.querySelector el "span"))))
 


### PR DESCRIPTION
Replaces the use of the non-standard method `Element.webkitMatchesSelector()` with `Element.matches()`. Closes #272.