### PR TITLE
Update Boot URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ the following libraries as dependencies to complete the stack:
 
 ### Quickstart
 
-Install [Boot](http://boot-clj.com) and then generate a starter project with:
+Install [Boot](https://boot-clj.github.io/) and then generate a starter project with:
 
     boot -d boot/new new -t hoplon -n hoplon-starter-project
 


### PR DESCRIPTION
https://boot-clj.com/ no longer points to the Boot building too, the new url is https://boot-clj.github.io/ .