### PR TITLE
Add config for clj-kondo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ phantomjsdriver.log
 .cpcache/
 cljs-test-runner-out/
 node_modules/
+.clj-kondo/**/

--- a/build.clj
+++ b/build.clj
@@ -30,7 +30,7 @@
       :basis (b/create-basis {})
       :class-dir class-dir
       :target "target"
-      :src-dirs ["src"])))
+      :src-dirs ["src" "clj-kondo"])))
 
 (defn ci "Run the CI pipeline of tests (and build the JAR)." [opts]
   (test opts)
@@ -39,7 +39,7 @@
     (println "\nWriting pom.xml...")
     (b/write-pom opts)
     (println "\nCopying source...")
-    (b/copy-dir {:src-dirs ["resources" "src"] :target-dir class-dir})
+    (b/copy-dir {:src-dirs ["src" "clj-kondo"] :target-dir class-dir})
     (println "\nBuilding JAR...")
     (b/jar opts))
   opts)

--- a/clj-kondo/clj-kondo.exports/hoplon/hoplon/clj_kondo/hoplon.clj
+++ b/clj-kondo/clj-kondo.exports/hoplon/hoplon/clj_kondo/hoplon.clj
@@ -1,0 +1,36 @@
+(ns clj-kondo.hoplon
+  (:require [clj-kondo.hooks-api :as api]))
+
+(defn hoplon-core-defelem
+  [{:keys [node]}]
+  (let [[_defelem name & forms]  (:children node)
+        [docstr & [args & body]] (if (api/string-node? (first forms))
+                                   forms
+                                   (concat [""] forms))]
+    {:node (api/list-node
+            (list*
+             (api/token-node 'defn)
+             name
+             docstr
+             (api/vector-node
+              [(api/token-node '&) args])
+             body))}))
+
+(defn hoplon-core-elem
+  [{:keys [node]}]
+  (let [[_elem & [args & body]] (:children node)]
+    {:node (api/list-node
+            (list*
+             (api/token-node 'fn)
+             (api/vector-node
+              [(api/token-node '&) args])
+             body))}))
+
+(defn hoplon-core-loop-tpl
+  [{:keys [node]}]
+  (let [[_loop-tpl _bindings-kw bind & body] (:children node)]
+    {:node (api/list-node
+            (list*
+             (api/token-node 'for)
+             bind
+             body))}))

--- a/clj-kondo/clj-kondo.exports/hoplon/hoplon/config.edn
+++ b/clj-kondo/clj-kondo.exports/hoplon/hoplon/config.edn
@@ -1,0 +1,11 @@
+{:lint-as {castra.core/defrpc      clojure.core/defn
+           hoplon.core/for-tpl     clojure.core/for
+           javelin.core/cell-let   clojure.core/let
+           javelin.core/cell-doseq clojure.core/doseq
+           javelin.core/defc       clojure.core/def
+           javelin.core/defc=      clojure.core/def
+           javelin.core/formulet   clojure.core/let
+           javelin.core/with-let   clojure.core/let}
+ :hooks   {:analyze-call {hoplon.core/elem     clj-kondo.hoplon/hoplon-core-elem
+                          hoplon.core/defelem  clj-kondo.hoplon/hoplon-core-defelem
+                          hoplon.core/loop-tpl clj-kondo.hoplon/hoplon-core-loop-tpl}}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:deps {org.clojure/clojurescript {:mvn/version "1.11.60"}
         hoplon/javelin {:mvn/version "3.9.0"}}
- :paths ["src"]
+ :paths ["src" "clj-kondo"]
  :aliases {:test {:extra-deps {olical/cljs-test-runner {:mvn/version "3.8.0"}
                                cljsjs/jquery {:mvn/version "3.2.1-0"}}
                   :extra-paths ["tst/src/cljs"]


### PR DESCRIPTION
It is easier at this moment to include config for castra and javelin here as those projects still use boot build tool but those should be moved as soon as it is practical.