### PR TITLE
Move cljsjs.jquery back to dependencies to please cljdoc atm

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,8 +1,8 @@
 {:deps {org.clojure/clojurescript {:mvn/version "1.11.60"}
-        hoplon/javelin {:mvn/version "3.9.0"}}
+        hoplon/javelin {:mvn/version "3.9.0"}
+        cljsjs/jquery {:mvn/version "3.4.0-0"}}
  :paths ["src" "clj-kondo"]
- :aliases {:test {:extra-deps {olical/cljs-test-runner {:mvn/version "3.8.0"}
-                               cljsjs/jquery {:mvn/version "3.2.1-0"}}
+ :aliases {:test {:extra-deps {olical/cljs-test-runner {:mvn/version "3.8.0"}}
                   :extra-paths ["tst/src/cljs"]
                   :main-opts ["-m" "cljs-test-runner.main"]}
            :build {:deps {io.github.clojure/tools.build {:git/tag "v0.9.2" :git/sha "fe6b140"}


### PR DESCRIPTION
Bump jquery version. This should not affect shadow-cljs users as it ignores cljsjs dependencies.