### PR TITLE
Make spec namespaces optional

### DIFF
--- a/src/hoplon/core.cljs
+++ b/src/hoplon/core.cljs
@@ -9,10 +9,7 @@
 (ns hoplon.core
   (:require [goog.Uri]
             [goog.object          :as obj]
-            [javelin.core         :refer [cell? cell]]
-            [cljs.spec.alpha      :as spec]
-            [cljs.spec.test.alpha :as spect]
-            [hoplon.spec])
+            [javelin.core         :refer [cell? cell]])
   (:require-macros [javelin.core :refer [with-let cell=]]
                    [hoplon.core  :refer [with-timeout]]))
 
@@ -64,20 +61,15 @@
           :else               (do (.insertBefore elem new-kid old-kid)
                                   (recur nks old-kids)))))))
 
-(defn- -do! [elem this value]
+(defn -do! [elem this value]
   (do! elem this value))
 
-(spec/fdef -do! :args :hoplon.spec/do! :ret any?)
-
-(defn- -on! [elem this value]
+(defn -on! [elem this value]
   (on! elem this value))
 
-(spec/fdef -on! :args :hoplon.spec/on! :ret any?)
-
-(defn- -elem! [elem this value]
+(defn -elem! [elem this value]
   (elem! elem this value))
 
-(spec/fdef -elem! :args :hoplon.spec/elem! :ret any?)
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Public Helpers ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -213,13 +205,6 @@
   Keyword
   (-attribute! [this elem value]
     (-elem! elem this value)))
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-;; Hoplon Runtime Spec ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-(defn spec! []
-  (spect/instrument `-elem!)
-  (spect/instrument `-do!)
-  (spect/instrument `-on!))
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Hoplon Elements ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/hoplon/goog.cljs
+++ b/src/hoplon/goog.cljs
@@ -5,8 +5,7 @@
             [goog.events        :as events]
             [goog.fx.dom        :as fxdom]
             [goog.style         :as style]
-            [hoplon.core        :refer [on! do! normalize-class]]
-            [hoplon.spec        :as spec])
+            [hoplon.core        :refer [on! do! normalize-class]])
   (:require-macros [hoplon.core :refer [with-timeout]]))
 
 ;; Google Closure Library Attributes ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -14,26 +13,14 @@
   [elem _ v]
   (domf/setValue elem v))
 
-(defmethod spec/do! :value
-  [_]
-  (spec/attr any?))
-
 (defmethod do! :class
   [elem _ kvs]
   (doseq [[c p?] (normalize-class kvs)]
     (domcl/enable elem (name c) (boolean p?))))
 
-(defmethod spec/do! :class
-  [_]
-  (spec/attr :hoplon.spec/class))
-
 (defmethod do! :toggle
   [elem _ v]
   (style/setElementShown elem (boolean v)))
-
-(defmethod spec/do! :toggle
-  [_]
-  (spec/attr :hoplon.spec/boolean))
 
 (defmethod do! :slide-toggle
   [elem _ v]
@@ -43,19 +30,11 @@
       (fxdom/swipe elem (style/getSize elem) [0 0]))
     (style/setElementShown elem (boolean v))))
 
-(defmethod spec/do! :slide-toggle
-  [_]
-  (spec/attr :hoplon.spec/boolean))
-
 (defmethod do! :fade-toggle
   [elem _ v]
   (if v
     (fxdom/fadeInAndShow elem 200)
     (fxdom/fadeOutAndHide elem 200)))
-
-(defmethod spec/do! :fade-toggle
-  [_]
-  (spec/attr :hoplon.spec/boolean))
 
 (defmethod do! :focus
   [elem _ v]
@@ -64,33 +43,17 @@
       (events/dispatchEvent elem goog.events.EventType.FOCUS)
       (events/dispatchEvent elem goog.events.EventType.FOCUSOUT))))
 
-(defmethod spec/do! :focus
-  [_]
-  (spec/attr :hoplon.spec/boolean))
-
 (defmethod do! :select
   [elem _ _]
   (events/dispatchEvent elem goog.events.EventType.SELECT))
-
-(defmethod spec/do! :select
-  [_]
-  (spec/attr :hoplon.spec/boolean))
 
 (defmethod do! :focus-select
   [elem _ v]
   (when v (do! elem :focus v) (do! elem :select v)))
 
-(defmethod spec/do! :focus-select
-  [_]
-  (spec/attr :hoplon.spec/boolean))
-
 (defmethod do! :text
   [elem _ v]
   (dom/setTextContent elem (str v)))
-
-(defmethod spec/do! :text
-  [_]
-  (spec/attr :hoplon.spec/string))
 
 (defmethod do! :html
   [elem _ v]
@@ -98,18 +61,10 @@
     (dom/removeChildren elem)
     (dom/appendChild elem (dom/safeHtmlToNode v))))
 
-(defmethod spec/do! :html
-  [_]
-  (spec/attr :hoplon.spec/string))
-
 (defmethod do! :scroll-to
   [elem _ v]
   (when v
     (style/scrollContinerIntoView elem (dom/getDocument))))
-
-(defmethod spec/do! :scroll-to
-  [_]
-  (spec/attr :hoplon.spec/boolean))
 
 (extend-type goog.events.BrowserEvent
   cljs.core/IDeref

--- a/src/hoplon/goog_spec.cljs
+++ b/src/hoplon/goog_spec.cljs
@@ -1,0 +1,49 @@
+(ns hoplon.goog-spec
+  (:require [cljs.spec.test.alpha :as spect]
+            [hoplon.core :as h]
+            [hoplon.spec :as hspec]))
+
+(defmethod hspec/do! :value
+  [_]
+  (hspec/attr any?))
+
+(defmethod hspec/do! :class
+  [_]
+  (hspec/attr :hoplon.spec/class))
+
+(defmethod hspec/do! :toggle
+  [_]
+  (hspec/attr boolean?))
+
+(defmethod hspec/do! :fade-toggle
+  [_]
+  (hspec/attr boolean?))
+
+(defmethod hspec/do! :focus
+  [_]
+  (hspec/attr boolean?))
+
+(defmethod hspec/do! :select
+  [_]
+  (hspec/attr boolean?))
+
+(defmethod hspec/do! :focus-select
+  [_]
+  (hspec/attr boolean?))
+
+(defmethod hspec/do! :text
+  [_]
+  (hspec/attr string?))
+
+(defmethod hspec/do! :html
+  [_]
+  (hspec/attr string?))
+
+(defmethod hspec/do! :scroll-to
+  [_]
+  (hspec/attr boolean?))
+
+(defn spec! []
+  (spect/instrument `h/-elem!)
+  (spect/instrument `h/-do!)
+  (spect/instrument `h/-on!))

--- a/src/hoplon/jquery.cljs
+++ b/src/hoplon/jquery.cljs
@@ -1,7 +1,6 @@
 (ns hoplon.jquery
   (:require [cljsjs.jquery]
-            [hoplon.core :refer [do! on! normalize-class]]
-            [hoplon.spec :as spec])
+            [hoplon.core :refer [do! on! normalize-class]])
   (:require-macros
     [hoplon.core :refer [with-timeout]]))
 
@@ -41,75 +40,39 @@
   [elem key val]
   (do! elem :attr {key val}))
 
-(defmethod spec/do! :hoplon.core/default
-  [_]
-  (spec/attr any?))
-
 (defmethod do! :css/default
   [elem key val]
   (set-styles! elem key val))
-
-(defmethod spec/do! :data/default
-  [_]
-  (spec/attr any?))
 
 (defmethod do! :html/default
   [elem key val]
   (set-attributes! elem key val))
 
-(defmethod spec/do! :html/default
-  [_]
-  (spec/attr any?))
-
 (defmethod do! :svg/default
   [elem key val]
   (set-attributes! elem key val))
 
-(defmethod spec/do! :svg/default
-  [_]
-  (spec/attr any?))
-
 (defmethod do! :attr/default
   [elem _ kvs]
   (set-attributes! elem kvs))
-
-(defmethod spec/do! :data/default
-  [_]
-  (spec/attr :hoplon.spec/map))
 
 (defmethod do! :prop/default
   [elem key val]
   (let [e (js/jQuery elem)]
     (.prop e (name key) val)))
 
-(defmethod spec/do! :prop/default
-  [_]
-  (spec/attr any?))
-
 (defmethod do! :data/default
   [elem key val]
   (let [e (js/jQuery elem)]
     (.data e (name key) val)))
 
-(defmethod spec/do! :data/default
-  [_]
-  (spec/attr any?))
-
 (defmethod do! :attr
   [elem _ kvs]
   (set-attributes! elem kvs))
 
-(defmethod spec/do! :attr
-  [_]
-  (spec/attr :hoplon.spec/map))
-
 (defmethod do! :css
   [elem _ kvs]
   (set-styles! elem kvs))
-
-(defmethod spec/do! :css
-  [_]
-  (spec/attr :hoplon.spec/map))
 
 (defmethod do! :value
   [elem _ & args]
@@ -120,35 +83,19 @@
       text-val!)
      e args)))
 
-(defmethod spec/do! :value
-  [_]
-  (spec/attr :hoplon.spec/value))
-
 (defmethod do! :class
   [elem _ kvs]
   (let [elem  (js/jQuery elem)
         clmap (normalize-class kvs)]
     (doseq [[c p?] clmap] (.toggleClass elem (name c) (boolean p?)))))
 
-(defmethod spec/do! :class
-  [_]
-  (spec/attr :hoplon.spec/class))
-
 (defmethod do! :class/default
   [elem _ kvs]
   (do! elem :class kvs))
 
-(defmethod spec/do! :class/default
-  [_]
-  (spec/attr :hoplon.spec/class))
-
 (defmethod do! :toggle
   [elem _ v]
   (.toggle (js/jQuery elem) (boolean v)))
-
-(defmethod spec/do! :toggle
-  [_]
-  (spec/attr :hoplon.spec/boolean))
 
 (defmethod do! :slide-toggle
   [elem _ v]
@@ -156,60 +103,32 @@
     (.slideDown (.hide (js/jQuery elem)) "fast")
     (.slideUp (js/jQuery elem) "fast")))
 
-(defmethod spec/do! :slide-toggle
-  [_]
-  (spec/attr :hoplon.spec/boolean))
-
 (defmethod do! :fade-toggle
   [elem _ v]
   (if v
     (.fadeIn (.hide (js/jQuery elem)) "fast")
     (.fadeOut (js/jQuery elem) "fast")))
 
-(defmethod spec/do! :fade-toggle
-  [_]
-  (spec/attr :hoplon.spec/boolean))
-
 (defmethod do! :focus
   [elem _ v]
   (with-timeout 0
     (if v (.focus (js/jQuery elem)) (.focusout (js/jQuery elem)))))
 
-(defmethod spec/do! :focus
-  [_]
-  (spec/attr :hoplon.spec/boolean))
-
 (defmethod do! :select
   [elem _ _]
   (.select (js/jQuery elem)))
-
-(defmethod spec/do! :select
-  [_]
-  (spec/attr :hoplon.spec/boolean))
 
 (defmethod do! :focus-select
   [elem _ v]
   (when v (do! elem :focus v) (do! elem :select v)))
 
-(defmethod spec/do! :focus-select
-  [_]
-  (spec/attr :hoplon.spec/boolean))
-
 (defmethod do! :text
   [elem _ v]
   (.text (js/jQuery elem) (str v)))
 
-(defmethod spec/do! :text
-  [_]
-  (spec/attr :hoplon.spec/string))
-
 (defmethod do! :html
   [elem _ v]
   (.html (js/jQuery elem) v))
-
-(defmethod spec/do! :html
-  [_]
-  (spec/attr :hoplon.spec/string))
 
 (defmethod do! :scroll-to
   [elem _ v]
@@ -217,10 +136,6 @@
     (let [body (js/jQuery "body,html")
           elem (js/jQuery elem)]
       (.animate body (clj->js {:scrollTop (.-top (.offset elem))})))))
-
-(defmethod spec/do! :scroll-to
-  [_]
-  (spec/attr :hoplon.spec/boolean))
 
 (extend-type js/jQuery.Event
   cljs.core/IDeref

--- a/src/hoplon/jquery_spec.cljs
+++ b/src/hoplon/jquery_spec.cljs
@@ -1,0 +1,93 @@
+(ns hoplon.jquery-spec
+  (:require [cljs.spec.test.alpha :as spect]
+            [hoplon.core :as h]
+            [hoplon.spec :as hspec]))
+
+(defmethod hspec/do! :hoplon.core/default
+  [_]
+  (hspec/attr any?))
+
+(defmethod hspec/do! :data/default
+  [_]
+  (hspec/attr any?))
+
+(defmethod hspec/do! :html/default
+  [_]
+  (hspec/attr any?))
+
+(defmethod hspec/do! :svg/default
+  [_]
+  (hspec/attr any?))
+
+(defmethod hspec/do! :data/default
+  [_]
+  (hspec/attr map?))
+
+(defmethod hspec/do! :prop/default
+  [_]
+  (hspec/attr any?))
+
+(defmethod hspec/do! :data/default
+  [_]
+  (hspec/attr any?))
+
+(defmethod hspec/do! :attr
+  [_]
+  (hspec/attr map?))
+
+(defmethod hspec/do! :css
+  [_]
+  (hspec/attr map?))
+
+(defmethod hspec/do! :value
+  [_]
+  (hspec/attr :hoplon.spec/value))
+
+(defmethod hspec/do! :class
+  [_]
+  (hspec/attr :hoplon.spec/class))
+
+(defmethod hspec/do! :class/default
+  [_]
+  (hspec/attr :hoplon.spec/class))
+
+(defmethod hspec/do! :toggle
+  [_]
+  (hspec/attr boolean?))
+
+(defmethod hspec/do! :slide-toggle
+  [_]
+  (hspec/attr boolean?))
+
+(defmethod hspec/do! :fade-toggle
+  [_]
+  (hspec/attr boolean?))
+
+(defmethod hspec/do! :focus
+  [_]
+  (hspec/attr boolean?))
+
+(defmethod hspec/do! :select
+  [_]
+  (hspec/attr boolean?))
+
+(defmethod hspec/do! :focus-select
+  [_]
+  (hspec/attr boolean?))
+
+(defmethod hspec/do! :text
+  [_]
+  (hspec/attr string?))
+
+(defmethod hspec/do! :html
+  [_]
+  (hspec/attr string?))
+
+(defmethod hspec/do! :scroll-to
+  [_]
+  (hspec/attr boolean?))
+
+(defn spec! []
+  (spect/instrument `h/-elem!)
+  (spect/instrument `h/-do!)
+  (spect/instrument `h/-on!))

--- a/src/hoplon/spec.cljs
+++ b/src/hoplon/spec.cljs
@@ -1,11 +1,8 @@
 (ns hoplon.spec
-  (:require [cljs.spec.alpha :as spec]))
+  (:require [cljs.spec.alpha :as spec]
+            [hoplon.core :as h]))
 
 ;; Attribute Specs ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-(spec/def ::elem any?)
-
-(spec/def ::attr keyword?)
-
 (spec/def ::class
   (spec/or
     :map map?
@@ -20,7 +17,7 @@
 
 ;; Attribute Provider Helpers ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defn attr [vspec]
-  (spec/cat :element ::elem :attribute ::attr :value vspec))
+  (spec/cat :element any? :attribute keyword? :value vspec))
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Attribute Provider Spec Multimethods ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -47,3 +44,7 @@
 
 (spec/def ::on! (spec/multi-spec on! ::on!))
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(spec/fdef h/-do! :args :hoplon.spec/do! :ret any?)
+(spec/fdef h/-on! :args :hoplon.spec/on! :ret any?)
+(spec/fdef h/-elem! :args :hoplon.spec/elem! :ret any?)


### PR DESCRIPTION
This makes it possible for users to not have a dependency on clojure spec on production builds. Currently, those are always included.

Thanks to @borkdude to point this out and to suggest the fix.

To use spec validation, the user will need to call `(hoplon.googl-spec/spec!)` or `(hoplon.jquery-spec/spec!)` depending on the provider they are using. This is a breaking change for people using spec validation, it used to be ` (hoplon.core/spec!)`.

Also, this fixes missing spec definitions that were causing runtime errors when the spec validation was on.